### PR TITLE
revert back kara root module

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -6,6 +6,7 @@
       <module fileurl="file://$PROJECT_DIR$/src/KaraExec/KaraExec.iml" filepath="$PROJECT_DIR$/src/KaraExec/KaraExec.iml" />
       <module fileurl="file://$PROJECT_DIR$/src/KaraLib/KaraLib.iml" filepath="$PROJECT_DIR$/src/KaraLib/KaraLib.iml" />
       <module fileurl="file://$PROJECT_DIR$/src/KaraTests/KaraTests.iml" filepath="$PROJECT_DIR$/src/KaraTests/KaraTests.iml" />
+      <module fileurl="file://$PROJECT_DIR$/kara.iml" filepath="$PROJECT_DIR$/kara.iml" />
     </modules>
   </component>
 </project>

--- a/kara.iml
+++ b/kara.iml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="KotlinRuntime" level="project" />
+  </component>
+</module>
+


### PR DESCRIPTION
Root module was handy to let see all non-module resources in IDEA
